### PR TITLE
Unescape HTML characters in page titles

### DIFF
--- a/lib/alfred/components/web_page.rb
+++ b/lib/alfred/components/web_page.rb
@@ -21,10 +21,18 @@ module Alfred
       end
 
       def title
-        @title ||= html.scan(/<title[^>]*>(.*?)<\/title>/).flatten.first
+        @title ||= unescaped_title_contents
       end
 
       private
+
+      def unescaped_title_contents
+        CGI.unescapeHTML(title_contents)
+      end
+
+      def title_contents
+        html.scan(/<title[^>]*>(.*?)<\/title>/).flatten.first
+      end
 
       def html
         @html ||= open(url).read

--- a/lib/spec/alfred/components/web_page_spec.rb
+++ b/lib/spec/alfred/components/web_page_spec.rb
@@ -27,5 +27,13 @@ RSpec.describe Alfred::Components::WebPage do
         expect(web_page.title).to eq(title)
       end
     end
+
+    context "when the title contains HTML encoded characters" do
+      let(:title) { "Vegetable Latkes | Mark&#039;s Daily Apple" }
+
+      it 'decodes them' do
+        expect(web_page.title).to eq("Vegetable Latkes | Mark's Daily Apple")
+      end
+    end
   end
 end


### PR DESCRIPTION
When creating a link page text note from a URL, HTML character codes are decoded to regular ASCII characters.