### PR TITLE
Fix for quick open action failing with notes that don't have a heading

### DIFF
--- a/lib/note_plan/note_components/heading.rb
+++ b/lib/note_plan/note_components/heading.rb
@@ -11,7 +11,21 @@ module NotePlan
   module NoteComponents
     class Heading < Base
       def contents
-        note_contents.scan(/^#[\s]+.*$/).first.gsub(/^# /, "")
+        first_heading_string.gsub(/^# /, "")
+      end
+
+      private
+
+      def first_heading_string
+        first_heading.to_s
+      end
+
+      def first_heading
+        headings.first
+      end
+
+      def headings
+        note_contents.scan(/^#[\s]+.*$/)
       end
     end
   end

--- a/lib/spec/note_plan/note_components/heading_spec.rb
+++ b/lib/spec/note_plan/note_components/heading_spec.rb
@@ -9,5 +9,13 @@ RSpec.describe NotePlan::NoteComponents::Heading do
     it 'extracts the first heading 1 from the note contents' do
       expect(component.contents).to eq("Heading 1")
     end
+
+    context "when the note contents do not contain a Markdown heading" do
+      let(:note_contents) { "Body\n\n" }
+
+      it 'is blank' do
+        expect(component.contents).to eq("")
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix for issue #12: Quick open fails when notes are present without a Markdown heading

Note that this allows quick open to work with notes that _do_ have a Markdown heading, but does not allow notes that don't have a heading to be opened through the Alfred workflow.

If there is a need to be able to quick open notes by treating the first line of the note as a heading, it may be possible to address that separately.