### PR TITLE
Issue #3: Allow base directory to be changed in workflow environment variables

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -769,6 +769,8 @@ See https://github.com/beet/alfred_noteplan_actions for a deatailed readme.</str
 		<string>prepend</string>
 		<key>todo_string</key>
 		<string>- [ ]</string>
+		<key>base_directory</key>
+		<string>/Library/Mobile Documents/iCloud~co~noteplan~NotePlan/Documents</string>
 	</dict>
 	<key>version</key>
 	<string>0.5.0</string>

--- a/lib/note_plan/base.rb
+++ b/lib/note_plan/base.rb
@@ -11,10 +11,6 @@ note files and yields a NotePlan::NoteFile instance.
 =end
 module NotePlan
   class Base
-    BASE_DIRECTORY = "#{ENV["HOME"]}/Library/Mobile Documents/iCloud~co~noteplan~NotePlan/Documents"
-    NOTES_DIRECTORY = "#{BASE_DIRECTORY}/Notes/*.txt"
-    CALENDAR_DIRECTORY = "#{BASE_DIRECTORY}/Calendar/*.txt"
-
     attr_reader :alfred_script_filter
 
     def initialize
@@ -30,15 +26,27 @@ module NotePlan
     private
 
     def for_each_note(&block)
-      Dir.glob(NOTES_DIRECTORY) do |filename|
+      Dir.glob(notes_directory) do |filename|
         yield NotePlan::NoteFile.new(filename)
       end
     end
 
     def for_each_calendar_entry(&block)
-      Dir.glob(CALENDAR_DIRECTORY) do |filename|
+      Dir.glob(calendar_directory) do |filename|
         yield NotePlan::NoteFile.new(filename)
       end
+    end
+
+    def notes_directory
+      "#{base_directory}/Notes/*.txt"
+    end
+
+    def calendar_directory
+      "#{base_directory}/Calendar/*.txt"
+    end
+
+    def base_directory
+      "#{ENV["HOME"]}#{Alfred::Settings.base_directory}"
     end
   end
 end

--- a/lib/spec/note_plan/base_spec.rb
+++ b/lib/spec/note_plan/base_spec.rb
@@ -22,8 +22,21 @@ RSpec.describe NotePlan::Base do
     end
   end
 
+  module Settings
+    def base_directory
+      method_missing(:base_directory)
+    end
+  end
+
+  before do
+    Alfred::Settings.extend(Settings)
+
+    allow(Alfred::Settings).to receive(:base_directory).and_return(base_directory)
+  end
+
   let(:alfred_item) { double(Alfred::Item, attributes: attributes) }
   let(:attributes) { { foo: "bar" } }
+  let(:base_directory) { "/Library/Mobile Documents/iCloud~co~noteplan~NotePlan/Documents" }
 
   subject(:concrete_class) { NotePlan::ConcreteClass.new }
 
@@ -60,7 +73,7 @@ RSpec.describe NotePlan::Base do
   end
 
   context "text note iteration" do
-    let(:notes_directory) { "#{ENV["HOME"]}/Library/Mobile Documents/iCloud~co~noteplan~NotePlan/Documents/Notes/*.txt" }
+    let(:notes_directory) { "#{ENV["HOME"]}#{base_directory}/Notes/*.txt" }
     let(:note_file) { double(NotePlan::NoteFile, filename: filename) }
     let(:filename) { "filename" }
 
@@ -76,7 +89,7 @@ RSpec.describe NotePlan::Base do
   end
 
   context "calendar note iteration" do
-    let(:notes_directory) { "#{ENV["HOME"]}/Library/Mobile Documents/iCloud~co~noteplan~NotePlan/Documents/Calendar/*.txt" }
+    let(:notes_directory) { "#{ENV["HOME"]}#{base_directory}/Calendar/*.txt" }
     let(:note_file) { double(NotePlan::NoteFile, filename: filename) }
     let(:filename) { "filename" }
 


### PR DESCRIPTION
Update for issue #3: Allow the base storage directory to be changed in Alfredworkflow environment variables.

Defaults to `~/Library/Mobile Documents/iCloud~co~noteplan~NotePlan/Documents` for iCloud, but could be changed to Dropbox by changing the `base_directory` environment variable.

Note that the path is relative, and will be pre-fixed with the home directory automatically.