### PR TITLE
feature: take the file extension from use settings

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -184,32 +184,6 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>concurrently</key>
-				<false/>
-				<key>escaping</key>
-				<integer>102</integer>
-				<key>script</key>
-				<string>require "./lib/note_plan"
-require "./lib/alfred"
-
-print Alfred::Actions::OpenNote.new(ARGV[0]).process</string>
-				<key>scriptargtype</key>
-				<integer>1</integer>
-				<key>scriptfile</key>
-				<string></string>
-				<key>type</key>
-				<integer>2</integer>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.script</string>
-			<key>uid</key>
-			<string>F387E1CB-87F3-4944-A1D3-42385BD31CBC</string>
-			<key>version</key>
-			<integer>2</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
 				<key>alfredfiltersresults</key>
 				<true/>
 				<key>alfredfiltersresultsmatchmode</key>
@@ -258,6 +232,32 @@ print NotePlan::QuickOpen.new.json</string>
 			<string>D54E0D31-4AEA-4F75-BC66-86EB9C59E88E</string>
 			<key>version</key>
 			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>require "./lib/note_plan"
+require "./lib/alfred"
+
+print Alfred::Actions::OpenNote.new(ARGV[0]).process</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>2</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>F387E1CB-87F3-4944-A1D3-42385BD31CBC</string>
+			<key>version</key>
+			<integer>2</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -409,6 +409,8 @@ print "[[#{query}]]"</string>
 				<true/>
 				<key>clipboardtext</key>
 				<string>{query}</string>
+				<key>ignoredynamicplaceholders</key>
+				<false/>
 				<key>transient</key>
 				<false/>
 			</dict>
@@ -478,6 +480,8 @@ print NotePlan::HashTags.new.json</string>
 				<true/>
 				<key>clipboardtext</key>
 				<string>{query} </string>
+				<key>ignoredynamicplaceholders</key>
+				<false/>
 				<key>transient</key>
 				<false/>
 			</dict>
@@ -764,7 +768,9 @@ See https://github.com/beet/alfred_noteplan_actions for a deatailed readme.</str
 	<key>variables</key>
 	<dict>
 		<key>base_directory</key>
-		<string>/Library/Mobile Documents/iCloud~co~noteplan~NotePlan/Documents</string>
+		<string>/Library/Containers/co.noteplan.NotePlan3/Data/Library/Application Support/co.noteplan.NotePlan3</string>
+		<key>file_extension</key>
+		<string>md</string>
 		<key>journal_heading</key>
 		<string>## Journal</string>
 		<key>quick_add_mode</key>

--- a/lib/note_plan/base.rb
+++ b/lib/note_plan/base.rb
@@ -26,13 +26,13 @@ module NotePlan
     private
 
     def for_each_note(&block)
-      Dir.glob("#{notes_directory}/*.txt") do |filename|
+      Dir.glob("#{notes_directory}/*.#{Alfred::Settings.file_extension}") do |filename|
         yield NotePlan::NoteFile.for(filename)
       end
     end
 
     def for_each_calendar_entry(&block)
-      Dir.glob("#{calendar_directory}/*.txt") do |filename|
+      Dir.glob("#{calendar_directory}/*.#{Alfred::Settings.file_extension}") do |filename|
         yield NotePlan::NoteFile.for(filename)
       end
     end

--- a/lib/spec/note_plan/base_spec.rb
+++ b/lib/spec/note_plan/base_spec.rb
@@ -26,17 +26,23 @@ RSpec.describe NotePlan::Base do
     def base_directory
       method_missing(:base_directory)
     end
+
+    def file_extension
+      method_missing(:file_extension)
+    end
   end
 
   before do
     Alfred::Settings.extend(Settings)
 
     allow(Alfred::Settings).to receive(:base_directory).and_return(base_directory)
+    allow(Alfred::Settings).to receive(:file_extension).and_return(file_extension)
   end
 
   let(:alfred_item) { double(Alfred::Item, attributes: attributes) }
   let(:attributes) { { foo: "bar" } }
   let(:base_directory) { "/Library/Mobile Documents/iCloud~co~noteplan~NotePlan/Documents" }
+  let(:file_extension) { "md" }
 
   subject(:concrete_class) { NotePlan::ConcreteClass.new }
 
@@ -73,7 +79,7 @@ RSpec.describe NotePlan::Base do
   end
 
   context "text note iteration" do
-    let(:notes_directory) { "#{ENV["HOME"]}#{base_directory}/Notes/*.txt" }
+    let(:notes_directory) { "#{ENV["HOME"]}#{base_directory}/Notes/*.#{file_extension}" }
     let(:note_file) { double(NotePlan::NoteFile, filename: filename) }
     let(:filename) { "filename" }
 
@@ -89,7 +95,7 @@ RSpec.describe NotePlan::Base do
   end
 
   context "calendar note iteration" do
-    let(:notes_directory) { "#{ENV["HOME"]}#{base_directory}/Calendar/*.txt" }
+    let(:notes_directory) { "#{ENV["HOME"]}#{base_directory}/Calendar/*.#{file_extension}" }
     let(:note_file) { double(NotePlan::NoteFile, filename: filename) }
     let(:filename) { "filename" }
 


### PR DESCRIPTION
Can change the extension from `txt` to `md`, or whatever you have it set to in NotePlan

Resolves #23 