### PR TITLE
Bunch of overdue fixes and updates

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -21,6 +21,32 @@
 				<false/>
 			</dict>
 		</array>
+		<key>133E36AE-E166-477E-A2E0-3A990ED8DC47</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>76EA634F-98D5-4B8C-A872-E2A73D21CD2C</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>37573988-5625-4631-81DE-735574313340</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>382FC0F4-A650-4ED8-B22E-A9370464F9D8</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 		<key>467968E3-37CE-4D02-A237-0FA82B846134</key>
 		<array>
 			<dict>
@@ -47,11 +73,37 @@
 				<false/>
 			</dict>
 		</array>
+		<key>6260EAD1-1ECD-48BA-8E20-B1BA4905F958</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>C755D7CA-76D8-4245-A5E5-3DA05319CB75</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 		<key>6F16FCDA-E554-405A-B2CD-55812DF85DF3</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
 				<string>AF430BBF-1499-45A3-807C-D5679E3B11C1</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>76EA634F-98D5-4B8C-A872-E2A73D21CD2C</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>37573988-5625-4631-81DE-735574313340</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -165,25 +217,6 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>browser</key>
-				<string></string>
-				<key>spaces</key>
-				<string></string>
-				<key>url</key>
-				<string>{query}</string>
-				<key>utf8</key>
-				<true/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.openurl</string>
-			<key>uid</key>
-			<string>0D429F71-F409-4444-BFD9-4FB61179F851</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
 				<key>alfredfiltersresults</key>
 				<true/>
 				<key>alfredfiltersresultsmatchmode</key>
@@ -262,6 +295,102 @@ print Alfred::Actions::OpenNote.new(ARGV[0]).process</string>
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>skipqueryencode</key>
+				<false/>
+				<key>skipvarencode</key>
+				<false/>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string>{query}</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>0D429F71-F409-4444-BFD9-4FB61179F851</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>alfredfiltersresults</key>
+				<true/>
+				<key>alfredfiltersresultsmatchmode</key>
+				<integer>2</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<false/>
+				<key>argumenttrimmode</key>
+				<integer>0</integer>
+				<key>argumenttype</key>
+				<integer>0</integer>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>keyword</key>
+				<string>nb</string>
+				<key>queuedelaycustom</key>
+				<integer>3</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<true/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string></string>
+				<key>script</key>
+				<string>require "./lib/alfred"
+require "./lib/note_plan"
+
+print NotePlan::RevealInFinder.new.json</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string>Pass a note into Alfred's full array of awesomeness!</string>
+				<key>title</key>
+				<string>Browse NotePlan note in Alfred</string>
+				<key>type</key>
+				<integer>2</integer>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.scriptfilter</string>
+			<key>uid</key>
+			<string>6260EAD1-1ECD-48BA-8E20-B1BA4905F958</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>path</key>
+				<string></string>
+				<key>sortBy</key>
+				<integer>0</integer>
+				<key>sortDirection</key>
+				<integer>0</integer>
+				<key>sortFoldersAtTop</key>
+				<false/>
+				<key>sortOverride</key>
+				<false/>
+				<key>stackBrowserView</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.browseinalfred</string>
+			<key>uid</key>
+			<string>C755D7CA-76D8-4245-A5E5-3DA05319CB75</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
 				<key>argumenttype</key>
 				<integer>0</integer>
 				<key>keyword</key>
@@ -277,6 +406,27 @@ print Alfred::Actions::OpenNote.new(ARGV[0]).process</string>
 			<string>alfred.workflow.input.keyword</string>
 			<key>uid</key>
 			<string>9737A391-0C8F-48BC-9D7F-9D804112585F</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>skipqueryencode</key>
+				<false/>
+				<key>skipvarencode</key>
+				<false/>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string>{query}</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>E574BFD8-2AA9-4FC4-8708-9C932079C9A4</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -305,25 +455,6 @@ print Alfred::Actions::AddTodo.new(ARGV[0]).process</string>
 			<string>98AA0FEB-B8FB-4411-A2B9-35ECC369F092</string>
 			<key>version</key>
 			<integer>2</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>browser</key>
-				<string></string>
-				<key>spaces</key>
-				<string></string>
-				<key>url</key>
-				<string>{query}</string>
-				<key>utf8</key>
-				<true/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.openurl</string>
-			<key>uid</key>
-			<string>E574BFD8-2AA9-4FC4-8708-9C932079C9A4</string>
-			<key>version</key>
-			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -424,6 +555,25 @@ print "[[#{query}]]"</string>
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>autopaste</key>
+				<true/>
+				<key>clipboardtext</key>
+				<string>{query} </string>
+				<key>ignoredynamicplaceholders</key>
+				<false/>
+				<key>transient</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.clipboard</string>
+			<key>uid</key>
+			<string>BE6DBA4B-0837-4736-8502-FFD1DCEEC1A6</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
 				<key>alfredfiltersresults</key>
 				<true/>
 				<key>alfredfiltersresultsmatchmode</key>
@@ -476,25 +626,6 @@ print NotePlan::HashTags.new.json</string>
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>autopaste</key>
-				<true/>
-				<key>clipboardtext</key>
-				<string>{query} </string>
-				<key>ignoredynamicplaceholders</key>
-				<false/>
-				<key>transient</key>
-				<false/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.output.clipboard</string>
-			<key>uid</key>
-			<string>BE6DBA4B-0837-4736-8502-FFD1DCEEC1A6</string>
-			<key>version</key>
-			<integer>3</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
 				<key>concurrently</key>
 				<false/>
 				<key>escaping</key>
@@ -517,6 +648,27 @@ print Alfred::Actions::AddLinkNote.new(ARGV[0]).process</string>
 			<string>6F16FCDA-E554-405A-B2CD-55812DF85DF3</string>
 			<key>version</key>
 			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>skipqueryencode</key>
+				<false/>
+				<key>skipvarencode</key>
+				<false/>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string>{query}</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>AF430BBF-1499-45A3-807C-D5679E3B11C1</string>
+			<key>version</key>
+			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -544,36 +696,40 @@ print Alfred::Actions::AddLinkNote.new(ARGV[0]).process</string>
 			<dict>
 				<key>browser</key>
 				<string></string>
+				<key>skipqueryencode</key>
+				<false/>
+				<key>skipvarencode</key>
+				<false/>
 				<key>spaces</key>
 				<string></string>
 				<key>url</key>
-				<string>{query}</string>
-				<key>utf8</key>
-				<true/>
+				<string></string>
 			</dict>
 			<key>type</key>
 			<string>alfred.workflow.action.openurl</string>
 			<key>uid</key>
-			<string>AF430BBF-1499-45A3-807C-D5679E3B11C1</string>
+			<string>CE3686D4-750F-45EA-87C7-053E69F86755</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>browser</key>
+				<key>argumenttype</key>
+				<integer>2</integer>
+				<key>keyword</key>
+				<string>js</string>
+				<key>subtext</key>
 				<string></string>
-				<key>spaces</key>
-				<string></string>
-				<key>url</key>
-				<string></string>
-				<key>utf8</key>
-				<true/>
+				<key>text</key>
+				<string>Journal Summary</string>
+				<key>withspace</key>
+				<false/>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.action.openurl</string>
+			<string>alfred.workflow.input.keyword</string>
 			<key>uid</key>
-			<string>CE3686D4-750F-45EA-87C7-053E69F86755</string>
+			<string>DAC024F8-5725-4685-A81C-3126018F8FFF</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -606,21 +762,80 @@ print Alfred::Actions::CreateJournalSummary.process</string>
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>argumenttype</key>
-				<integer>2</integer>
-				<key>keyword</key>
-				<string>js</string>
-				<key>subtext</key>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>time_block_text = '{query}'
+
+print "#{time_block_text} #{Time.now.strftime('%l:%M%P')}"
+  .gsub('  ', ' ')
+  # .gsub(/(.*)([\d]+):([\d]{2})([\w]+)/, "#{$1}#{$2}:#{($3.to_i / 10.0).floor * 10}#{$4}")</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
 				<string></string>
-				<key>text</key>
-				<string>Journal Summary</string>
-				<key>withspace</key>
+				<key>type</key>
+				<integer>2</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>37573988-5625-4631-81DE-735574313340</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>focusedappvariable</key>
+				<false/>
+				<key>focusedappvariablename</key>
+				<string></string>
+				<key>keyword</key>
+				<string>tb`</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.trigger.snippet</string>
+			<key>uid</key>
+			<string>133E36AE-E166-477E-A2E0-3A990ED8DC47</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>autopaste</key>
+				<true/>
+				<key>clipboardtext</key>
+				<string>{query}</string>
+				<key>ignoredynamicplaceholders</key>
+				<false/>
+				<key>transient</key>
 				<false/>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.input.keyword</string>
+			<string>alfred.workflow.output.clipboard</string>
 			<key>uid</key>
-			<string>DAC024F8-5725-4685-A81C-3126018F8FFF</string>
+			<string>382FC0F4-A650-4ED8-B22E-A9370464F9D8</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argument</key>
+				<string>{var:time_block_text}</string>
+				<key>passthroughargument</key>
+				<false/>
+				<key>variables</key>
+				<dict/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.argument</string>
+			<key>uid</key>
+			<string>76EA634F-98D5-4B8C-A872-E2A73D21CD2C</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -636,135 +851,183 @@ See https://github.com/beet/alfred_noteplan_actions for a deatailed readme.</str
 		<key>0C5FD526-22A5-44DB-9C94-66665CE4CB1E</key>
 		<dict>
 			<key>xpos</key>
-			<integer>260</integer>
+			<real>260</real>
 			<key>ypos</key>
-			<integer>990</integer>
+			<real>990</real>
 		</dict>
 		<key>0D429F71-F409-4444-BFD9-4FB61179F851</key>
 		<dict>
 			<key>xpos</key>
-			<integer>470</integer>
+			<real>470</real>
 			<key>ypos</key>
-			<integer>30</integer>
+			<real>30</real>
+		</dict>
+		<key>133E36AE-E166-477E-A2E0-3A990ED8DC47</key>
+		<dict>
+			<key>note</key>
+			<string>Insert a timeblock string</string>
+			<key>xpos</key>
+			<real>40</real>
+			<key>ypos</key>
+			<real>1270</real>
+		</dict>
+		<key>37573988-5625-4631-81DE-735574313340</key>
+		<dict>
+			<key>xpos</key>
+			<real>310</real>
+			<key>ypos</key>
+			<real>1270</real>
+		</dict>
+		<key>382FC0F4-A650-4ED8-B22E-A9370464F9D8</key>
+		<dict>
+			<key>xpos</key>
+			<real>495</real>
+			<key>ypos</key>
+			<real>1270</real>
 		</dict>
 		<key>467968E3-37CE-4D02-A237-0FA82B846134</key>
 		<dict>
 			<key>note</key>
 			<string>Paste a URL, and a new text note will be created using the website's title for the heading with a link to the site and the #links hashtag.</string>
 			<key>xpos</key>
-			<integer>40</integer>
+			<real>40</real>
 			<key>ypos</key>
-			<integer>760</integer>
+			<real>760</real>
 		</dict>
 		<key>565CEEFB-4C22-4E01-B1E4-721F43BC4276</key>
 		<dict>
 			<key>note</key>
 			<string>Insert a hashtag from the existing hashtags in your text notes with fuzzy search</string>
 			<key>xpos</key>
-			<integer>40</integer>
+			<real>40</real>
 			<key>ypos</key>
-			<integer>570</integer>
+			<real>570</real>
+		</dict>
+		<key>6260EAD1-1ECD-48BA-8E20-B1BA4905F958</key>
+		<dict>
+			<key>note</key>
+			<string>Browse notes in Alfred</string>
+			<key>xpos</key>
+			<real>650</real>
+			<key>ypos</key>
+			<real>35</real>
 		</dict>
 		<key>6F16FCDA-E554-405A-B2CD-55812DF85DF3</key>
 		<dict>
 			<key>xpos</key>
-			<integer>260</integer>
+			<real>260</real>
 			<key>ypos</key>
-			<integer>760</integer>
+			<real>760</real>
+		</dict>
+		<key>76EA634F-98D5-4B8C-A872-E2A73D21CD2C</key>
+		<dict>
+			<key>xpos</key>
+			<real>215</real>
+			<key>ypos</key>
+			<real>1300</real>
 		</dict>
 		<key>793F4654-386B-4CE2-B264-E21D3CF2C657</key>
 		<dict>
 			<key>xpos</key>
-			<integer>480</integer>
+			<real>480</real>
 			<key>ypos</key>
-			<integer>390</integer>
+			<real>390</real>
 		</dict>
 		<key>9737A391-0C8F-48BC-9D7F-9D804112585F</key>
 		<dict>
 			<key>note</key>
 			<string>Quick capture of todos from anywhere. Will be appended to today's calendar note.</string>
 			<key>xpos</key>
-			<integer>40</integer>
+			<real>40</real>
 			<key>ypos</key>
-			<integer>200</integer>
+			<real>200</real>
 		</dict>
 		<key>98AA0FEB-B8FB-4411-A2B9-35ECC369F092</key>
 		<dict>
 			<key>xpos</key>
-			<integer>255</integer>
+			<real>255</real>
 			<key>ypos</key>
-			<integer>200</integer>
+			<real>200</real>
 		</dict>
 		<key>AF430BBF-1499-45A3-807C-D5679E3B11C1</key>
 		<dict>
 			<key>xpos</key>
-			<integer>490</integer>
+			<real>490</real>
 			<key>ypos</key>
-			<integer>760</integer>
+			<real>760</real>
 		</dict>
 		<key>BD9E31D7-F171-4174-B726-A44C2DAE83EC</key>
 		<dict>
 			<key>note</key>
 			<string>Insert a wiki link to any text note with fuzzy search by heading</string>
 			<key>xpos</key>
-			<integer>40</integer>
+			<real>40</real>
 			<key>ypos</key>
-			<integer>390</integer>
+			<real>390</real>
 		</dict>
 		<key>BE6DBA4B-0837-4736-8502-FFD1DCEEC1A6</key>
 		<dict>
 			<key>xpos</key>
-			<integer>260</integer>
+			<real>260</real>
 			<key>ypos</key>
-			<integer>570</integer>
+			<real>570</real>
+		</dict>
+		<key>C755D7CA-76D8-4245-A5E5-3DA05319CB75</key>
+		<dict>
+			<key>xpos</key>
+			<real>865</real>
+			<key>ypos</key>
+			<real>35</real>
 		</dict>
 		<key>CE3686D4-750F-45EA-87C7-053E69F86755</key>
 		<dict>
 			<key>xpos</key>
-			<integer>485</integer>
+			<real>485</real>
 			<key>ypos</key>
-			<integer>990</integer>
+			<real>990</real>
 		</dict>
 		<key>D54E0D31-4AEA-4F75-BC66-86EB9C59E88E</key>
 		<dict>
 			<key>note</key>
 			<string>Open any text note from anywhere by searching by heading</string>
 			<key>xpos</key>
-			<integer>40</integer>
+			<real>40</real>
 			<key>ypos</key>
-			<integer>30</integer>
+			<real>30</real>
 		</dict>
 		<key>DAC024F8-5725-4685-A81C-3126018F8FFF</key>
 		<dict>
 			<key>note</key>
 			<string>Produces a Markdown summary of journal entries extracted from NotePlan's calendar notes</string>
 			<key>xpos</key>
-			<integer>40</integer>
+			<real>40</real>
 			<key>ypos</key>
-			<integer>990</integer>
+			<real>990</real>
 		</dict>
 		<key>E574BFD8-2AA9-4FC4-8708-9C932079C9A4</key>
 		<dict>
 			<key>xpos</key>
-			<integer>480</integer>
+			<real>480</real>
 			<key>ypos</key>
-			<integer>200</integer>
+			<real>200</real>
 		</dict>
 		<key>EB82F64E-90B1-4F50-8A6A-F5AF6DBEEAF1</key>
 		<dict>
 			<key>xpos</key>
-			<integer>260</integer>
+			<real>260</real>
 			<key>ypos</key>
-			<integer>390</integer>
+			<real>390</real>
 		</dict>
 		<key>F387E1CB-87F3-4944-A1D3-42385BD31CBC</key>
 		<dict>
 			<key>xpos</key>
-			<integer>250</integer>
+			<real>250</real>
 			<key>ypos</key>
-			<integer>30</integer>
+			<real>30</real>
 		</dict>
 	</dict>
+	<key>userconfigurationconfig</key>
+	<array/>
 	<key>variables</key>
 	<dict>
 		<key>base_directory</key>
@@ -775,9 +1038,20 @@ See https://github.com/beet/alfred_noteplan_actions for a deatailed readme.</str
 		<string>## Journal</string>
 		<key>quick_add_mode</key>
 		<string>prepend</string>
+		<key>time_block_text</key>
+		<string>⏱️</string>
 		<key>todo_string</key>
 		<string>- [ ]</string>
 	</dict>
+	<key>variablesdontexport</key>
+	<array>
+		<string>todo_string</string>
+		<string>file_extension</string>
+		<string>base_directory</string>
+		<string>journal_heading</string>
+		<string>quick_add_mode</string>
+		<string>time_block_text</string>
+	</array>
 	<key>version</key>
 	<string>0.9.0</string>
 	<key>webaddress</key>

--- a/lib/Gemfile.lock
+++ b/lib/Gemfile.lock
@@ -23,4 +23,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.17.1
+   2.1.4

--- a/lib/alfred/components/web_page.rb
+++ b/lib/alfred/components/web_page.rb
@@ -21,17 +21,21 @@ module Alfred
       end
 
       def title
-        @title ||= unescaped_title_contents
+        title_string = title_contents || open_graph_title
+
+        return if title_string.nil?
+
+        @title ||= CGI.unescapeHTML(title_string)
       end
 
       private
 
-      def unescaped_title_contents
-        CGI.unescapeHTML(title_contents)
-      end
-
       def title_contents
         html.scan(/<title[^>]*>(.*?)<\/title>/).flatten.first
+      end
+
+      def open_graph_title
+        html.scan(/<meta property="og:title" content="(.*)"( \/)?>/).flatten.first
       end
 
       def html

--- a/lib/note_plan/base.rb
+++ b/lib/note_plan/base.rb
@@ -27,13 +27,19 @@ module NotePlan
 
     def for_each_note(&block)
       Dir.glob("#{notes_directory}/**/*.#{Alfred::Settings.file_extension}") do |filename|
-        yield NotePlan::NoteFile.for(filename)
+        yield NotePlan::NoteFile.for(
+          filename,
+          base_directory: notes_directory,
+        )
       end
     end
 
     def for_each_calendar_entry(&block)
       Dir.glob("#{calendar_directory}/*.#{Alfred::Settings.file_extension}") do |filename|
-        yield NotePlan::NoteFile.for(filename)
+        yield NotePlan::NoteFile.for(
+          filename,
+          base_directory: calendar_directory,
+        )
       end
     end
 

--- a/lib/note_plan/note_components/note_date.rb
+++ b/lib/note_plan/note_components/note_date.rb
@@ -35,27 +35,60 @@ module NotePlan
       end
 
       def date_formatted
-        date.strftime("%Y-%m-%d")
+        return date.strftime("%Y-%m-%d") if daily?
+        return "Week #{weekly_week}" if weekly?
+        return date.strftime('%B') if monthly?
+        return yearly_year if yearly?
       end
 
       def date_human
-        date.strftime("%A %B %-d %Y")
+        return date.strftime("%A %B %-d %Y") if daily?
+        return daily_year if weekly?
+        return daily_year if monthly?
+        return 'yearly' if yearly?
+      end
+
+      private
+
+      def daily?
+        /^[\d]{8}\./.match?(filename)
+      end
+
+      def weekly?
+        /^[\d]{4}-W[\d]{2}\./.match?(filename)
+      end
+
+      def monthly?
+        /^[\d]{4}-[\d]{2}\./.match?(filename)
+      end
+
+      def yearly?
+        /^[\d]{4}\./.match?(filename)
       end
 
       def date
-        Date.new(year, month, day)
+        Date.new(daily_year, daily_month, daily_day || 1)
       end
 
-      def year
-        filename.match(/^([\d]{4})/)[0].to_i
+      def daily_year
+        filename.match(/^([\d]{4})/)[0]&.to_i
       end
 
-      def month
-        filename.match(/^[\d]{4}([\d]{2})/)[1].to_i
+      def daily_month
+        filename.match(/^[\d]{4}-([\d]{2})\./)&.[](1)&.to_i ||
+          filename.match(/^[\d]{4}([\d]{2})/)[1]&.to_i
       end
 
-      def day
-        filename.match(/^[\d]{4}[\d]{2}([\d]{2})/)[1].to_i
+      def daily_day
+        filename.match(/^[\d]{4}[\d]{2}([\d]{2})/)&.[](1)&.to_i
+      end
+
+      def weekly_week
+        filename.match(/^[\d]{4}-W([\d]{2})\./)[1]
+      end
+
+      def yearly_year
+        filename.match(/^([\d]{4})\./)[1]
       end
     end
   end

--- a/lib/note_plan/note_file.rb
+++ b/lib/note_plan/note_file.rb
@@ -26,8 +26,10 @@ module NotePlan
       # Documents/iCloud~co~noteplan~NotePlan/Documents/Calendar/20200303.txt"
       # will evaluate to NotePlan::NoteFiles::Calendar, and for text notes to
       # NotePlan::NoteFiles::Notes
-      def for(filename)
-        File.basename(File.dirname(filename)) == "Calendar" ? NotePlan::NoteFiles::Calendar.new(filename) : NotePlan::NoteFiles::Notes.new(filename)
+      def for(filename, base_directory:)
+        return NotePlan::NoteFiles::Calendar.new(filename, base_directory: base_directory) if File.basename(File.dirname(filename)) == "Calendar"
+
+        NotePlan::NoteFiles::Notes.new(filename, base_directory: base_directory)
       end
     end
   end

--- a/lib/note_plan/note_files/base.rb
+++ b/lib/note_plan/note_files/base.rb
@@ -20,10 +20,13 @@ PORO to encapsulate a note file:
 module NotePlan
   module NoteFiles
     class Base
-      attr_reader :filename
+      class AbstractMethodError < StandardError; end
 
-      def initialize(filename)
+      attr_reader :filename, :base_directory
+
+      def initialize(filename, base_directory:)
         @filename = filename
+        @base_directory = base_directory
       end
 
       def contents
@@ -34,15 +37,25 @@ module NotePlan
         File.basename(filename)
       end
 
-      def heading; end
+      def relative_path
+        filename.gsub(/^#{base_directory}\//, '')
+      end
+
+      def heading
+        raise AbstractMethodError, 'concrete implementations must define the #heading abstract method'
+      end
 
       def hashtags
         NoteComponents::HashTag.new(contents).contents
       end
 
-      def has_journal_entry?; end
+      def has_journal_entry?
+        raise AbstractMethodError, 'concrete implementations must define the #has_journal_entry? abstract method'
+      end
 
-      def journal_entry; end
+      def journal_entry
+        raise AbstractMethodError, 'concrete implementations must define the #journal_entry abstract method'
+      end
 
       def date
         note_date.date

--- a/lib/note_plan/quick_open.rb
+++ b/lib/note_plan/quick_open.rb
@@ -28,7 +28,7 @@ module NotePlan
       Alfred::Item.new(
         note_file.heading,
         subtitle: note_file.basename,
-        arg: note_file.heading
+        arg: note_file.relative_path,
       )
     end
   end

--- a/lib/note_plan/reveal_in_finder.rb
+++ b/lib/note_plan/reveal_in_finder.rb
@@ -1,0 +1,21 @@
+=begin
+
+Produces JSON for the Alfred script filter input to search notes by their
+heading, and pass the full filename into Alfred's browse workflow:
+
+    print NotePlan::RevealInFinder.new.json
+
+=end
+module NotePlan
+  class RevealInFinder < QuickOpen
+    private
+
+    def alfred_item_for(note_file)
+      Alfred::Item.new(
+        note_file.heading,
+        subtitle: note_file.basename,
+        arg: note_file.filename
+      )
+    end
+  end
+end

--- a/lib/note_plan/x_callback_url/open_note.rb
+++ b/lib/note_plan/x_callback_url/open_note.rb
@@ -10,7 +10,7 @@ module NotePlan
     class OpenNote < Base
       def parameters
         {
-          noteTitle: input
+          filename: input
         }
       end
     end

--- a/lib/spec/alfred/components/web_page_spec.rb
+++ b/lib/spec/alfred/components/web_page_spec.rb
@@ -35,5 +35,35 @@ RSpec.describe Alfred::Components::WebPage do
         expect(web_page.title).to eq("Vegetable Latkes | Mark's Daily Apple")
       end
     end
+
+    context "when there is no <title> element" do
+      let(:html) { "<!DOCTYPE html><html><head></head><body><h1>Heading</h1><p>Contents</p></body></html>" }
+
+      it 'is blank' do
+        expect(subject.title).to eq(nil)
+      end
+
+      context 'but there is an Open Graph title element' do
+        let(:html) {
+          <<~HTML
+            <!DOCTYPE html>
+            <html>
+              <head>
+                <meta property="og:title" content="#{title}">
+              </head>
+              <body>
+                <h1>Heading</h1>
+
+                <p>Contents</p>
+              </body>
+            </html>
+          HTML
+        }
+
+        it 'is the metadata contents' do
+          expect(subject.title).to eq(title)
+        end
+      end
+    end
   end
 end

--- a/lib/spec/note_plan/base_spec.rb
+++ b/lib/spec/note_plan/base_spec.rb
@@ -80,13 +80,20 @@ RSpec.describe NotePlan::Base do
 
   context "text note iteration" do
     let(:notes_directory) { "#{ENV["HOME"]}#{base_directory}/Notes/**/*.#{file_extension}" }
-    let(:note_file) { double(NotePlan::NoteFile, filename: filename) }
+    let(:notes_base_directory) { "#{ENV["HOME"]}#{base_directory}/Notes" }
+    let(:note_file) {
+      instance_double(
+        NotePlan::NoteFiles::Notes,
+        filename: filename,
+        base_directory: notes_base_directory,
+      )
+    }
     let(:filename) { "filename" }
 
     before do
       allow(Dir).to receive(:glob).with(notes_directory).and_yield(filename)
 
-      allow(NotePlan::NoteFile).to receive(:for).with(filename).and_return(note_file)
+      allow(NotePlan::NoteFile).to receive(:for).with(filename, base_directory: notes_base_directory).and_return(note_file)
     end
 
     it 'yields a NotePlan::NoteFile object instantiated with each filename in the text notes directory' do
@@ -96,13 +103,20 @@ RSpec.describe NotePlan::Base do
 
   context "calendar note iteration" do
     let(:notes_directory) { "#{ENV["HOME"]}#{base_directory}/Calendar/*.#{file_extension}" }
-    let(:note_file) { double(NotePlan::NoteFile, filename: filename) }
+    let(:calendar_base_directory) { "#{ENV["HOME"]}#{base_directory}/Calendar" }
+    let(:note_file) {
+      instance_double(
+        NotePlan::NoteFiles::Calendar,
+        filename: filename,
+        base_directory: calendar_base_directory,
+      )
+    }
     let(:filename) { "filename" }
 
     before do
       allow(Dir).to receive(:glob).with(notes_directory).and_yield(filename)
 
-      allow(NotePlan::NoteFile).to receive(:for).with(filename).and_return(note_file)
+      allow(NotePlan::NoteFile).to receive(:for).with(filename, base_directory: calendar_base_directory).and_return(note_file)
     end
 
     it 'yields a NotePlan::NoteFile object instantiated with each filename in the calendar notes directory' do

--- a/lib/spec/note_plan/note_components/note_date_spec.rb
+++ b/lib/spec/note_plan/note_components/note_date_spec.rb
@@ -5,60 +5,71 @@ RSpec.describe NotePlan::NoteComponents::NoteDate do
 
   subject(:note_date) { NotePlan::NoteComponents::NoteDate.new(filename) }
 
-  context "#date" do
-    let(:year) { 2019 }
-    let(:month) { 8 }
-    let(:day) { 22 }
-    let(:date) { double(Date) }
+  describe "#date_formatted" do
+    context 'for daily notes' do
+      let(:filename) { '20230619.md' }
 
-    before do
-      allow(Date).to receive(:new).with(year, month, day).and_return(date)
+      it 'is the date in YYYY-MM-DD format' do
+        expect(subject.date_formatted).to eq('2023-06-19')
+      end
     end
 
-    it 'constructs a date from the year, month, and day' do
-      expect(note_date.date).to eq(date)
-    end
-  end
+    context 'for weekly notes' do
+      let(:filename) { '2023-W01.md' }
 
-  context "#year" do
-    it 'extracts the year from the filename' do
-      expect(note_date.year).to eq(2019)
-    end
-  end
-
-  context "#month" do
-    it 'extracts the month from the filename' do
-      expect(note_date.month).to eq(8)
-    end
-  end
-
-  context "#day" do
-    it 'extracts the day from the filename' do
-      expect(note_date.day).to eq(22)
-    end
-  end
-
-  context "#date_formatted" do
-    let(:date) { Date.today }
-
-    before do
-      allow(note_date).to receive(:date).and_return(date)
+      it 'is the formatted week number' do
+        expect(subject.date_formatted).to eq('Week 01')
+      end
     end
 
-    it 'is the date in YYYY-MM-DD format' do
-      expect(note_date.date_formatted).to eq(date.strftime("%Y-%m-%d"))
+    context 'for monthly notes' do
+      let(:filename) { '2023-01.md' }
+
+      it 'is the formatted month name' do
+        expect(subject.date_formatted).to eq('January')
+      end
+    end
+
+    context 'for yearly notes' do
+      let(:filename) { '2023.md' }
+
+      it 'is the year' do
+        expect(subject.date_formatted).to eq('2023')
+      end
     end
   end
 
   context "#date_human" do
-    let(:date) { Date.today }
+    context 'for daily notes' do
+      let(:filename) { '20230619.md' }
 
-    before do
-      allow(note_date).to receive(:date).and_return(date)
+      it 'is the date in "Wednesday March 4 2020" format' do
+        expect(note_date.date_human).to eq('Monday June 19 2023')
+      end
     end
 
-    it 'is the date in "Wednesday March 4 2020" format' do
-      expect(note_date.date_human).to eq(date.strftime("%A %B %-d %Y"))
+    context 'for weekly notes' do
+      let(:filename) { '2023-W01.md' }
+
+      it 'is the year' do
+        expect(subject.date_human).to eq(2023)
+      end
+    end
+
+    context 'for monthly notes' do
+      let(:filename) { '2023-01.md' }
+
+      it 'is the year' do
+        expect(subject.date_human).to eq(2023)
+      end
+    end
+
+    context 'for yearly notes' do
+      let(:filename) { '2023.md' }
+
+      it 'is "yearly"' do
+        expect(subject.date_human).to eq('yearly')
+      end
     end
   end
 end

--- a/lib/spec/note_plan/note_file_spec.rb
+++ b/lib/spec/note_plan/note_file_spec.rb
@@ -2,10 +2,11 @@ require "spec_helper"
 
 RSpec.describe NotePlan::NoteFile do
   context "for" do
-    subject(:note_file) { NotePlan::NoteFile.for(filename) }
+    subject(:note_file) { described_class.for(filename, base_directory: base_directory) }
 
     context "with the path to a calendar note" do
       let(:filename) { "/Users/foo/Library/Mobile Documents/iCloud~co~noteplan~NotePlan/Documents/Calendar/20200303.txt" }
+      let(:base_directory) { "/Users/foo/Library/Mobile Documents/iCloud~co~noteplan~NotePlan/Documents/Calendar" }
 
       it 'is a NotePlan::NoteFiles::Calendar instance' do
         expect(note_file).to be_a(NotePlan::NoteFiles::Calendar)
@@ -14,6 +15,7 @@ RSpec.describe NotePlan::NoteFile do
 
     context "with the path to a text note" do
       let(:filename) { "/Users/foo/Library/Mobile Documents/iCloud~co~noteplan~NotePlan/Documents/Notes/Title.txt" }
+      let(:base_directory) { "/Users/foo/Library/Mobile Documents/iCloud~co~noteplan~NotePlan/Documents/Notes" }
 
       it 'is a NotePlan::NoteFiles::Notes instance' do
         expect(note_file).to be_a(NotePlan::NoteFiles::Notes)
@@ -21,7 +23,6 @@ RSpec.describe NotePlan::NoteFile do
 
       context "that is in a sub-folder" do
         let(:filename) { "/Users/foo/Library/Containers/co.noteplan.NotePlan3/Data/Library/Application Support/co.noteplan.NotePlan3/Notes/@Trash/Title.md" }
-
 
         it 'is a NotePlan::NoteFiles::Notes instance' do
           expect(note_file).to be_a(NotePlan::NoteFiles::Notes)

--- a/lib/spec/note_plan/note_files/calendar_spec.rb
+++ b/lib/spec/note_plan/note_files/calendar_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe NotePlan::NoteFiles::Calendar do
   let(:filename) { "foo/filename.txt" }
+  let(:base_directory) { 'foo/Bar' }
 
-  subject(:note_file) { NotePlan::NoteFiles::Calendar.new(filename) }
+  subject(:note_file) { described_class.new(filename, base_directory: base_directory) }
 
   it_behaves_like NotePlan::NoteFiles::Base
 

--- a/lib/spec/note_plan/note_files/notes_spec.rb
+++ b/lib/spec/note_plan/note_files/notes_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe NotePlan::NoteFiles::Notes do
   let(:filename) { "foo/filename.txt" }
+  let(:base_directory) { 'foo/Bar' }
 
-  subject(:note_file) { NotePlan::NoteFiles::Notes.new(filename) }
+  subject(:note_file) { described_class.new(filename, base_directory: base_directory) }
 
   it_behaves_like NotePlan::NoteFiles::Base
 

--- a/lib/spec/note_plan/reveal_in_finder_spec.rb
+++ b/lib/spec/note_plan/reveal_in_finder_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
-RSpec.describe NotePlan::QuickOpen do
-  subject(:quick_open) { NotePlan::QuickOpen.new }
+RSpec.describe NotePlan::RevealInFinder do
+  subject(:subject) { described_class.new }
 
   context "#alfred_items" do
     let(:note_file_1) {
@@ -9,24 +9,24 @@ RSpec.describe NotePlan::QuickOpen do
         NotePlan::NoteFiles::Notes,
         heading: heading_1,
         basename: basename_1,
-        relative_path: relative_path_1,
+        filename: filename_1,
       )
     }
     let(:heading_1) { "heading_1" }
     let(:basename_1) { "basename_1" }
-    let(:relative_path_1) { 'relative_path_1' }
+    let(:filename_1) { "filename_1" }
 
     let(:note_file_2) {
       instance_double(
         NotePlan::NoteFiles::Calendar,
         heading: heading_2,
         basename: basename_2,
-        relative_path: relative_path_2,
+        filename: filename_2,
       )
     }
     let(:heading_2) { "heading_2" }
     let(:basename_2) { "basename_2" }
-    let(:relative_path_2) { 'relative_path_2' }
+    let(:filename_2) { "filename_2" }
 
     let(:alfred_item_1) { instance_double(Alfred::Item, title: title_1) }
     let(:title_1) { "title_B" }
@@ -39,7 +39,7 @@ RSpec.describe NotePlan::QuickOpen do
         .with(
           heading_1,
           subtitle: basename_1,
-          arg: relative_path_1,
+          arg: filename_1
         )
         .and_return(alfred_item_1)
 
@@ -47,15 +47,15 @@ RSpec.describe NotePlan::QuickOpen do
         .with(
           heading_2,
           subtitle: basename_2,
-          arg: relative_path_2,
+          arg: filename_2
         )
         .and_return(alfred_item_2)
 
-      allow(quick_open).to receive(:for_each_note).and_yield(note_file_1).and_yield(note_file_2)
+      allow(subject).to receive(:for_each_note).and_yield(note_file_1).and_yield(note_file_2)
     end
 
     it "sorts a collection of Alfred::Item objects for each file note" do
-      expect(quick_open.alfred_items).to eq([alfred_item_2, alfred_item_1])
+      expect(subject.alfred_items).to eq([alfred_item_2, alfred_item_1])
     end
   end
 end

--- a/lib/spec/note_plan/x_callback_url/open_note_spec.rb
+++ b/lib/spec/note_plan/x_callback_url/open_note_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe NotePlan::XCallbackUrl::OpenNote do
   context "#parameters" do
     let(:parameters) { callback.parameters }
 
-    context ":noteTitle" do
+    context ":filename" do
       it 'is the given input' do
-        expect(parameters[:noteTitle]).to eq(input)
+        expect(parameters[:filename]).to eq(input)
       end
     end
   end

--- a/lib/spec/spec_helper.rb
+++ b/lib/spec/spec_helper.rb
@@ -97,6 +97,7 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+  config.default_formatter = "doc"
 
   require_relative "../alfred"
   require_relative "../note_plan"


### PR DESCRIPTION
* Fix: create notes from links to pages with OpenGraph metadata instead of title tags
* Fix: Quick-open search now works with weekly/monthly/year notes and subdirectories
* Feature: can send notes to Alfred's browse dialogue to reveal in Finder etc.

Resolves #28 

